### PR TITLE
Correct contributing part of README according to travis config

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -218,6 +218,8 @@ For testing, generate a temporary Rails dummy app inside test:
   rake dummy:setup
   rake app:db:migrate
   rake app:db:migrate RAILS_ENV=test
+  export BUNDLE_GEMFILE=$PWD/Gemfile
+  cd test/dummy && rake db:migrate db:test:prepare
   rake test
 
 Please add test cases when adding new functionality. I started with some basic example integration tests for a very basic coverage.


### PR DESCRIPTION
As I can see we _always_ need to use dummy app for testing.

We should define `BUNDLE_GEMFILE` env variable or set correct default gemfile path in dummy application:
replace

``` ruby
ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
```

by

``` ruby
ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
```

everywhere in dummy app
