### PR TITLE
Support for using the same captcha in multiple forms of the same page

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ fill_in 'captcha', with: SimpleCaptcha::SimpleCaptchaData.first.value
 * ``:label`` - provides the custom text b/w the image and the text field, the default is "type the code from the image"
 * ``:object`` - the name of the object of the model class, to implement the model based captcha.
 * ``:code_type`` - return numeric only if set to 'numeric'
+* ``:multiple`` - allow to use the same captcha in multiple forms in one page. True for the first appaerance and false for the rest.
 
 ###Global options
 

--- a/lib/simple_captcha/view.rb
+++ b/lib/simple_captcha/view.rb
@@ -44,7 +44,13 @@ module SimpleCaptcha #:nodoc
     # All Feedbacks/CommentS/Issues/Queries are welcome.
     def show_simple_captcha(options={})
       key = simple_captcha_key(options[:object])
-      options[:field_value] = set_simple_captcha_data(key, options)
+      if options[:multiple] === false
+        # It's not the first captcha, we only need to return the key
+        options[:field_value] = key
+      else
+        # It's the first captcha in the page, we generate a new key
+        options[:field_value] = set_simple_captcha_data(key, options)        
+      end
       
       defaults = {
          :image => simple_captcha_image(key, options),


### PR DESCRIPTION
I'm using simple-captcha to confirm multiple actions in the same page. Each action must be confirmed inside a bootstrap modal, so I ended with multiple forms.

I got the idea for the solution from here: http://stackoverflow.com/questions/3683920/problems-with-simple-captcha
