### PR TITLE
fix: avoid 'create_migration' method conflict

### DIFF
--- a/lib/generators/simple_captcha_generator.rb
+++ b/lib/generators/simple_captcha_generator.rb
@@ -2,7 +2,7 @@ require 'rails/generators'
 
 class SimpleCaptchaGenerator < Rails::Generators::Base
   include Rails::Generators::Migration
-                          
+
   def self.source_root
     @source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'templates/'))
   end
@@ -10,12 +10,12 @@ class SimpleCaptchaGenerator < Rails::Generators::Base
   def self.next_migration_number(dirname)
     Time.now.strftime("%Y%m%d%H%M%S")
   end
-  
+
   def create_partial
     template "partial.erb", File.join('app/views', 'simple_captcha', "_simple_captcha.erb")
   end
-  
-  def create_migration
+
+  def create_captcha_migration
     migration_template "migration.rb", File.join('db/migrate', "create_simple_captcha_data.rb")
   end
 end


### PR DESCRIPTION
I just renamed the method and it worked fine.
My rails version is 4.1.0.
