### PR TITLE
Add possibility to set `implode` valude for the generated image

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ You can also specify 'random' to select the random image style.
 
 * ``:distortion`` - handles the complexity of the image. The :distortion can be set to 'low', 'medium' or 'high'. Default is 'low'.
 
+* ``:implode`` - handles the complexity of the image. The :implode can be set to 'none', 'low', 'medium' or 'high'. Default is 'medium'.
+
 Create "./config/initializers/simple_captcha.rb"
 
 ```ruby
@@ -217,6 +219,10 @@ SimpleCaptcha.setup do |sc|
   # default: low
   # possible values: 'low', 'medium', 'high', 'random'
   sc.distortion = 'medium'
+
+  # default: medium
+  # possible values: 'none', 'low', 'medium', 'high'
+  sc.implode = 'low'
 end
 ```
 

--- a/lib/simple_captcha.rb
+++ b/lib/simple_captcha.rb
@@ -47,6 +47,10 @@ module SimpleCaptcha
   mattr_accessor :distortion
   @@distortion = 'low'
 
+  # 'none', 'low', 'medium', 'high'
+  mattr_accessor :implode
+  @@implode = SimpleCaptcha::ImageHelpers::DEFAULT_IMPLODE
+
   # command path
   mattr_accessor :image_magick_path
   @@image_magick_path = ''

--- a/lib/simple_captcha/image.rb
+++ b/lib/simple_captcha/image.rb
@@ -16,6 +16,9 @@ module SimpleCaptcha #:nodoc
 
     DISTORTIONS = ['low', 'medium', 'high']
 
+    IMPLODES = { 'none' => 0, 'low' => 0.1, 'medium' => 0.2, 'high' => 0.3 }
+    DEFAULT_IMPLODE = 'medium'
+
     class << self
 
       def image_params(key = 'simply_blue')
@@ -43,6 +46,10 @@ module SimpleCaptcha #:nodoc
           when 'high' then return [4 + rand(2), 30 + rand(20)]
         end
       end
+
+      def implode
+        IMPLODES[SimpleCaptcha.implode] || IMPLODES[DEFAULT_IMPLODE]
+      end
     end
 
     if RUBY_VERSION < '1.9'
@@ -67,7 +74,7 @@ module SimpleCaptcha #:nodoc
         #params << "-gravity 'Center'"
         params << "-gravity \"Center\""
         params << "-pointsize 22"
-        params << "-implode 0.2"
+        params << "-implode #{ImageHelpers.implode}"
 
         dst = Tempfile.new(RUBY_VERSION < '1.9' ? 'simple_captcha.jpg' : ['simple_captcha', '.jpg'], SimpleCaptcha.tmp_path)
         dst.binmode


### PR DESCRIPTION
See https://github.com/pludoni/simple-captcha/issues/19 for details.
