### PR TITLE
Ruby 2.2.0: Fix warning

### DIFF
--- a/lib/simple_captcha/view.rb
+++ b/lib/simple_captcha/view.rb
@@ -133,8 +133,8 @@ module SimpleCaptcha #:nodoc
         return value
       end
 
-      def simple_captcha_key(key_name = nil, request = request)
-        local_session = request.try(:session) || session
+      def simple_captcha_key(key_name = nil, prequest = request)
+        local_session = prequest.try(:session) || session
         if key_name.nil?
           local_session[:captcha] ||= SimpleCaptcha::Utils.generate_key(local_session[:id].to_s, 'captcha')
         else


### PR DESCRIPTION
simple_captcha2-0.3.2/lib/simple_captcha/view.rb:136: warning: circular argument reference - request

I don't think is a good idea to call the parameter the same as the default value object.
