### PR TITLE
Fix mass-assignment error when using protected_attributes

### DIFF
--- a/lib/simple_captcha/simple_captcha_data.rb
+++ b/lib/simple_captcha/simple_captcha_data.rb
@@ -15,7 +15,7 @@ module SimpleCaptcha
 
     class << self
       def get_data(key)
-        where(key: key).first || new(key: key)
+        where(key: key).first_or_initialize
       end
 
       def remove_data(key)


### PR DESCRIPTION
The following code does not work as intended because we use protected_attributes gem in Rails 4:
```ruby
SimpleCaptchaData.new(key: key)
```