### PR TITLE
Little improvements

### DIFF
--- a/lib/simple_captcha.rb
+++ b/lib/simple_captcha.rb
@@ -63,6 +63,12 @@ module SimpleCaptcha
   mattr_accessor :noise
   @@noise = 0
 
+  mattr_accessor :extra_response_headers
+  @@extra_response_headers = {}
+
+  mattr_accessor :partial_path
+  @@partial_path = 'simple_captcha/simple_captcha'
+
   def self.add_image_style(name, params = [])
     SimpleCaptcha::ImageHelpers.image_styles.update(name.to_s => params)
   end

--- a/lib/simple_captcha/form_builder.rb
+++ b/lib/simple_captcha/form_builder.rb
@@ -36,7 +36,7 @@ module SimpleCaptcha
           html[:placeholder] = options[:placeholder] || I18n.t('simple_captcha.placeholder')
 
           text_field(:captcha, html) +
-          hidden_field(:captcha_key, {:value => options[:field_value]})
+          hidden_field(:captcha_key, {:value => options[:field_value], :id => simple_captch_hidden_field_id(options)})
         end
     end
   end

--- a/lib/simple_captcha/middleware.rb
+++ b/lib/simple_captcha/middleware.rb
@@ -84,7 +84,7 @@ module SimpleCaptcha
                     $("##{id}").attr('src', '#{url}');
                     $("#captcha_key").attr('value', '#{key}');
                   }
-        headers = {'Content-Type' => 'text/javascript; charset=utf-8', "Content-Disposition" => "inline; filename='captcha.js'", "Content-Length" => body.length.to_s}
+        headers = {'Content-Type' => 'text/javascript; charset=utf-8', "Content-Disposition" => "inline; filename='captcha.js'", "Content-Length" => body.length.to_s}.merge(SimpleCaptcha.extra_response_headers)
         [status, headers, [body]]
       end
   end

--- a/lib/simple_captcha/middleware.rb
+++ b/lib/simple_captcha/middleware.rb
@@ -79,10 +79,11 @@ module SimpleCaptcha
 
         status = 200
         id = request.params['id']
+        captcha_hidden_field_id = simple_captch_hidden_field_id(id)
 
         body = %Q{
                     $("##{id}").attr('src', '#{url}');
-                    $("#captcha_key").attr('value', '#{key}');
+                    $("##{ captcha_hidden_field_id }").attr('value', '#{key}');
                   }
         headers = {'Content-Type' => 'text/javascript; charset=utf-8', "Content-Disposition" => "inline; filename='captcha.js'", "Content-Length" => body.length.to_s}.merge(SimpleCaptcha.extra_response_headers)
         [status, headers, [body]]

--- a/lib/simple_captcha/utils.rb
+++ b/lib/simple_captcha/utils.rb
@@ -29,7 +29,7 @@ module SimpleCaptcha #:nodoc
     end
 
     def self.generate_key(*args)
-      args << Time.now.to_s
+      args << (Time.now.to_f * 1_000_000_000).to_s
       Digest::SHA1.hexdigest(args.join)
     end
   end

--- a/lib/simple_captcha/view.rb
+++ b/lib/simple_captcha/view.rb
@@ -42,7 +42,11 @@ module SimpleCaptcha #:nodoc
     # Find more detailed examples with sample images here on my blog http://EXPRESSICA.com
     #
     # All Feedbacks/CommentS/Issues/Queries are welcome.
-    def show_simple_captcha(options={})
+    def show_simple_captcha(options = {})
+      render :partial => SimpleCaptcha.partial_path, :locals => { :simple_captcha_options => simple_captcha_options(options) }
+    end
+
+    def simple_captcha_options(options = {})
       key = simple_captcha_key(options[:object])
       if options[:multiple] === false
         # It's not the first captcha, we only need to return the key
@@ -58,8 +62,6 @@ module SimpleCaptcha #:nodoc
         :field => simple_captcha_field(options),
         :refresh_button => simple_captcha_refresh_button(options),
       }.merge(options)
-
-      render :partial => SimpleCaptcha.partial_path, :locals => { :simple_captcha_options => defaults }
     end
 
     private

--- a/lib/simple_captcha/view.rb
+++ b/lib/simple_captcha/view.rb
@@ -78,6 +78,10 @@ module SimpleCaptcha #:nodoc
 
         query = defaults.to_query
         path = "/simple_captcha?code=#{simple_captcha_key}&#{query}"
+        build_url(options, path)
+      end
+
+      def build_url(options, path)
         if defined?(request) && request
           "#{request.protocol}#{request.host_with_port}#{ENV['RAILS_RELATIVE_URL_ROOT']}#{path}"
         else
@@ -105,7 +109,8 @@ module SimpleCaptcha #:nodoc
 
         text = options[:refresh_button_text] || I18n.t('simple_captcha.refresh_button_text', default: 'Refresh')
 
-        link_to(text, "#{ENV['RAILS_RELATIVE_URL_ROOT']}/simple_captcha?id=#{simple_captcha_image_id(options)}", html)
+        url = build_url(options, "/simple_captcha?id=#{simple_captcha_image_id(options)}")
+        link_to(text, url, html)
       end
 
       def simple_captcha_image_id(options={})

--- a/lib/simple_captcha/view.rb
+++ b/lib/simple_captcha/view.rb
@@ -90,10 +90,10 @@ module SimpleCaptcha #:nodoc
 
         if options[:object]
           text_field(options[:object], :captcha, html.merge(:value => '')) +
-          hidden_field(options[:object], :captcha_key, {:value => options[:field_value]})
+          hidden_field(options[:object], :captcha_key, {:value => options[:field_value], :id => simple_captch_hidden_field_id(options)})
         else
           text_field_tag(:captcha, nil, html) +
-          hidden_field_tag(:captcha_key, options[:field_value])
+          hidden_field_tag(:captcha_key, options[:field_value], :id => simple_captch_hidden_field_id(options))
         end
       end
 
@@ -108,6 +108,11 @@ module SimpleCaptcha #:nodoc
 
       def simple_captcha_image_id(options={})
         "simple_captcha-#{options[:field_value][0..10]}"
+      end
+
+      def simple_captch_hidden_field_id(image_id)
+        image_id = simple_captcha_image_id(image_id) if image_id.is_a?(Hash)
+        "simple-captcha-hidden-field-#{ image_id }"
       end
 
       def set_simple_captcha_data(key, options={})

--- a/lib/simple_captcha/view.rb
+++ b/lib/simple_captcha/view.rb
@@ -59,7 +59,7 @@ module SimpleCaptcha #:nodoc
         :refresh_button => simple_captcha_refresh_button(options),
       }.merge(options)
 
-      render :partial => 'simple_captcha/simple_captcha', :locals => { :simple_captcha_options => defaults }
+      render :partial => SimpleCaptcha.partial_path, :locals => { :simple_captcha_options => defaults }
     end
 
     private


### PR DESCRIPTION
1. Allow capability for user to add extra headers in response, like cross-origin.
2. use `(Time.now.to_f * 1_000_000_000).to_s` because 2 requests may occur at same time, so use nanoseconds.
3. If multiple captchas are on the same page, then unique id has been assigned to captcha_key. It will also fixed #29 automatically.
4. extract url cration logic and used in image and refresh_button link.