### PR TITLE
remove the '-evaluate Uniform-noise' parameter

### DIFF
--- a/lib/simple_captcha/image.rb
+++ b/lib/simple_captcha/image.rb
@@ -75,7 +75,6 @@ module SimpleCaptcha #:nodoc
         params << "-pointsize 22"
         params << "-implode #{ImageHelpers.implode}"
         params << "label:#{text}"
-        params << "-evaluate Uniform-noise #{SimpleCaptcha.noise}"
         params << "jpeg:-"
 
         SimpleCaptcha::Utils::run("convert", params.join(' '))


### PR DESCRIPTION
The Uniform-noise parameter is unavailable in older ImageMagick versions. Removing it increases compatibility, and I didn't notice any noticable change in the appearance of the captcha images.