### PR TITLE
Set the format of the refresh procedure by configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ You can setup in which format the reload of the captcha is executed:
 
 ```ruby
 SimpleCaptcha.setup do |sc|
-  sc.refresh_format = 'prototype' # or jquery, default is jquery
+  sc.refresh_format = :prototype # or jquery, default is jquery
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,14 @@ SimpleCaptcha.setup do |sc|
 end
 ```
 
+You can setup in which format the reload of the captcha is executed:
+
+```ruby
+SimpleCaptcha.setup do |sc|
+  sc.refresh_format = 'prototype' # or jquery, default is jquery
+end
+```
+
 
 ### How to change the CSS for SimpleCaptcha DOM elements?
 

--- a/lib/simple_captcha.rb
+++ b/lib/simple_captcha.rb
@@ -51,6 +51,10 @@ module SimpleCaptcha
   mattr_accessor :implode
   @@implode = SimpleCaptcha::ImageHelpers::DEFAULT_IMPLODE
 
+  # 'jquery', 'prototype'
+  mattr_accessor :refresh_format
+  @@refresh_format = 'jquery'
+
   # command path
   mattr_accessor :image_magick_path
   @@image_magick_path = ''

--- a/lib/simple_captcha.rb
+++ b/lib/simple_captcha.rb
@@ -53,7 +53,7 @@ module SimpleCaptcha
 
   # 'jquery', 'prototype'
   mattr_accessor :refresh_format
-  @@refresh_format = 'jquery'
+  @@refresh_format = :jquery
 
   # command path
   mattr_accessor :image_magick_path

--- a/lib/simple_captcha/middleware.rb
+++ b/lib/simple_captcha/middleware.rb
@@ -80,11 +80,20 @@ module SimpleCaptcha
         status = 200
         id = request.params['id']
         captcha_hidden_field_id = simple_captch_hidden_field_id(id)
+        format = SimpleCaptcha.refresh_format
 
-        body = %Q{
-                    $("##{id}").attr('src', '#{url}');
-                    $("##{ captcha_hidden_field_id }").attr('value', '#{key}');
-                  }
+        if format == "jquery"
+          body = %Q{
+                      $("##{id}").attr('src', '#{url}');
+                      $("##{ captcha_hidden_field_id }").attr('value', '#{key}');
+                    }
+        elsif format == "prototype"
+          body = %Q{
+                      $("#{id}").setAttribute('src', '#{url}');
+                      $("#{ captcha_hidden_field_id }").setAttribute('value', '#{key}');
+                    }
+        end
+
         headers = {'Content-Type' => 'text/javascript; charset=utf-8', "Content-Disposition" => "inline; filename='captcha.js'", "Content-Length" => body.length.to_s}.merge(SimpleCaptcha.extra_response_headers)
         [status, headers, [body]]
       end

--- a/lib/simple_captcha/version.rb
+++ b/lib/simple_captcha/version.rb
@@ -1,3 +1,3 @@
 module SimpleCaptcha
-  VERSION = "0.4.1".freeze
+  VERSION = "0.4.2".freeze
 end

--- a/lib/simple_captcha/version.rb
+++ b/lib/simple_captcha/version.rb
@@ -1,3 +1,3 @@
 module SimpleCaptcha
-  VERSION = "0.4.0".freeze
+  VERSION = "0.4.1".freeze
 end

--- a/simple_captcha.gemspec
+++ b/simple_captcha.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.summary = "SimpleCaptcha is the simplest and a robust captcha plugin."
   s.description = "SimpleCaptcha is available to be used with Rails 3 + 4 or above and also it provides the backward compatibility with previous versions of Rails."
-  s.authors = ["Pavlo Galeta", "Igor Galeta", 'Stefan Wienert']
+  s.authors = ["Pavlo Galeta", "Igor Galeta", 'Stefan Wienert', 'Konrad Mallok']
   s.email = "stwienert@gmail.com"
   s.homepage = "http://github.com/pludoni/simple-captcha"
 

--- a/simple_captcha2.gemspec
+++ b/simple_captcha2.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.summary = "SimpleCaptcha is the simplest and a robust captcha plugin."
   s.description = "SimpleCaptcha is available to be used with Rails 3 + 4 or above and also it provides the backward compatibility with previous versions of Rails."
-  s.authors = ["Pavlo Galeta", "Igor Galeta", 'Stefan Wienert']
+  s.authors = ["Pavlo Galeta", "Igor Galeta", 'Stefan Wienert', 'Konrad Mallok']
   s.email = "stwienert@gmail.com"
   s.homepage = "http://github.com/pludoni/simple-captcha"
 


### PR DESCRIPTION
This pull request enables to let the user set the type of javascript framework is used to refresh the actual captcha image.
