### PR TITLE
stderr should not be copied into the output file

### DIFF
--- a/lib/simple_captcha/utils.rb
+++ b/lib/simple_captcha/utils.rb
@@ -5,7 +5,6 @@ module SimpleCaptcha #:nodoc
     # Execute command with params and return output if exit status equal expected_outcodes
     def self.run(cmd, params = "", expected_outcodes = 0)
       command = %Q[#{cmd} #{params}].gsub(/\s+/, " ")
-      command = "#{command} 2>&1"
 
       unless (image_magick_path = SimpleCaptcha.image_magick_path).blank?
         command = File.join(image_magick_path, command)


### PR DESCRIPTION
Copying stderr into the output file may cause invalid files and also expose information about the server. stderr must not be copied into the output file.
See here for an invalid jpg which was generated by simple-captcha. After removing the trailing payload up the the JFIF magic string, the file is actually a valid jpeg containing a working captcha. https://gist.github.com/spixi/fccdd98e51336e0e9230b2a2741dac56