### PR TITLE
Move -font parameter before label parameter

### DIFF
--- a/lib/simple_captcha/image.rb
+++ b/lib/simple_captcha/image.rb
@@ -74,10 +74,10 @@ module SimpleCaptcha #:nodoc
         params << "-gravity Center"
         params << "-pointsize 22"
         params << "-implode #{ImageHelpers.implode}"
-        params << "label:#{text}"
         unless SimpleCaptcha.font.empty?
           params << "-font #{SimpleCaptcha.font}"
         end
+        params << "label:#{text}"
         if SimpleCaptcha.noise and SimpleCaptcha.noise > 0
           params << "-evaluate Uniform-noise #{SimpleCaptcha.noise}"
         end


### PR DESCRIPTION
I just had the problem from #52, but the fix from #55 didn't help, still the same error message.

After a bit of try and error I found out, that the order of the parameters matter and the `-font` parameter needs to be before the `label:`. So this fails:
```
convert label:foo -font DejaVu-Sans jpeg:-
```
while this works:
```
convert -font DejaVu-Sans label:foo jpeg:-
```

(tested on debian stretch)