### PR TITLE
Support running tests with Rails 5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,7 @@ end
 if ENV['DB'] and ENV['DB']['postgresql']
   gem 'pg'
 end
+
+gem "bootsnap", "~> 1.3"
+
+gem "puma", "~> 3.12"

--- a/lib/generators/simple_captcha_generator.rb
+++ b/lib/generators/simple_captcha_generator.rb
@@ -17,6 +17,12 @@ class SimpleCaptchaGenerator < Rails::Generators::Base
   end
 
   def create_captcha_migration
-    migration_template "migration.rb", File.join('db/migrate', "create_simple_captcha_data.rb")
+    migration_template migration_file, File.join('db/migrate', "create_simple_captcha_data.rb")
+  end
+
+  private
+
+  def migration_file
+    Rails::VERSION::MAJOR > 4 ? "migration5.rb" : "migration.rb"
   end
 end

--- a/lib/generators/templates/migration5.rb
+++ b/lib/generators/templates/migration5.rb
@@ -1,0 +1,15 @@
+class CreateSimpleCaptchaData < ActiveRecord::Migration[4.2]
+  def self.up
+    create_table :simple_captcha_data do |t|
+      t.string :key, :limit => 40
+      t.string :value, :limit => 6
+      t.timestamps
+    end
+
+    add_index :simple_captcha_data, :key, :name => "idx_key"
+  end
+
+  def self.down
+    drop_table :simple_captcha_data
+  end
+end

--- a/test/features/form_helper_test.rb
+++ b/test/features/form_helper_test.rb
@@ -3,7 +3,8 @@ require 'simple_captcha/controller'
 
 class FormHelperTest  < ActionDispatch::IntegrationTest
   include Capybara::DSL
-  self.use_transactional_fixtures = false
+  self.use_transactional_tests = false if Rails::VERSION::MAJOR >= 5
+  self.use_transactional_fixtures = false if Rails::VERSION::MAJOR < 5
 
   setup do
     SimpleCaptcha.always_pass = false

--- a/test/features/formtastic_test.rb
+++ b/test/features/formtastic_test.rb
@@ -1,7 +1,8 @@
 if defined? Formtastic
   require 'test_helper'
   class FormtasticTest  < ActionDispatch::IntegrationTest
-    self.use_transactional_fixtures = false
+    self.use_transactional_tests = false if Rails::VERSION::MAJOR >= 5
+    self.use_transactional_fixtures = false if Rails::VERSION::MAJOR < 5
     include Capybara::DSL
 
     setup do


### PR DESCRIPTION
At #63 @zealot128 asks me to add tests to my PR. So I started with trying to run tests in the project by following the readme file.

The Gemfile in the project defaults to the latest Rails 5 version (5.2 as for now). But the actual tests code doesn't work with Rails 5.2. Here I added changes with which the tests work again with the latest Rails as defined in the Gemfile.

Changes required by Rails 5:
- Puma is now the default webserver so must be in the Gemfile
- `ActiveRecord::Migration` must be referenced by Rails version
- `use_transactional_fixtures` is now `use_transactional_tests`

A change required by Rails 5.2:
- Requires [bootsnap](https://weblog.rubyonrails.org/2017/11/27/Rails-5-2-Active-Storage-Redis-Cache-Store-HTTP2-Early-Hints-Credentials/) to be in the Gemfile