### PR TITLE
simple_captcha_data: ignore all error during data flushing

### DIFF
--- a/lib/simple_captcha/simple_captcha_data.rb
+++ b/lib/simple_captcha/simple_captcha_data.rb
@@ -19,14 +19,18 @@ module SimpleCaptcha
       end
 
       def remove_data(key)
-        where(["#{connection.quote_column_name(:key)} = ?", key]).delete_all
-        clear_old_data(1.hour.ago)
+        begin
+          where(["#{connection.quote_column_name(:key)} = ?", key]).delete_all
+          clear_old_data(1.hour.ago)
+        rescue StandardError => err
+          Rails.logger.error "#{err.class} #{err.message}"
+        end
       end
 
       def clear_old_data(time = 1.hour.ago)
         return unless Time === time
         where(["#{connection.quote_column_name(:updated_at)} < ?", time]).delete_all
-      rescue ActiveRecord::Deadlocked => err
+      rescue StandardError => err
         Rails.logger.error "#{err.class} #{err.message}"
       end
     end


### PR DESCRIPTION
Workaround for MySQL2:Error that happens times to times after call to `#simpla_captcha_passed!` on call of `SimpleCaptchaData#remove_data`.

The issue only occurs on my CI, I can't reproduce it outside of it and I don't have enough context to fully understand what and why, but it is a less big deal to have remaining data in the DB times to times than raising an exception killing the current request handler if the DB clean-up fail.

In case someone wants to investigate deeper:
![image](https://user-images.githubusercontent.com/18233250/216637512-5fdbb0a7-57f3-4989-961a-6aebfc5dc993.png)



